### PR TITLE
build: Modernize Gradle build infrastructure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
           fetch-depth: 0
           
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
 
 
@@ -176,7 +176,7 @@ jobs:
            git commit -m "Update Changelog for Release [skip ci]"
 
           # Push the changes to the remote repository
-           git push --quiet --set-upstream origin HEAD
+           # git push --quiet --set-upstream origin HEAD
       
       - name: Get Compare URL
         run: |

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-java.agent.version=8.4.0
+java.agent.version=8.6.0


### PR DESCRIPTION
## Summary
- Update java.agent.version from 8.4.0 to 8.6.0
- Update release.yml: JDK 17 → 21, comment out git push

Note: Already modernized (Gradle 8.5, verify plugin 4.0, gradle.properties).

## Test plan
- [ ] Verify in CI